### PR TITLE
Fixed a bug where bot would look at reaction removals on all messages…

### DIFF
--- a/amongusevents/amongusevents.go
+++ b/amongusevents/amongusevents.go
@@ -63,9 +63,11 @@ func extractEventState(session *discordgo.Session, message *discordgo.Message) (
 	}
 
 	var attendingUsers []string
-	for _, user := range rsvpYes {
-		if !user.Bot {
-			attendingUsers = append(attendingUsers, user.Username)
+	if rsvpYes != nil {
+		for _, user := range rsvpYes {
+			if !user.Bot {
+				attendingUsers = append(attendingUsers, user.Username)
+			}
 		}
 	}
 
@@ -75,9 +77,11 @@ func extractEventState(session *discordgo.Session, message *discordgo.Message) (
 	}
 
 	var notAttendingUsers []string
-	for _, user := range rsvpNo {
-		if !user.Bot {
-			notAttendingUsers = append(notAttendingUsers, user.Username)
+	if rsvpNo != nil {
+		for _, user := range rsvpNo {
+			if !user.Bot {
+				notAttendingUsers = append(notAttendingUsers, user.Username)
+			}
 		}
 	}
 
@@ -87,9 +91,11 @@ func extractEventState(session *discordgo.Session, message *discordgo.Message) (
 	}
 
 	var timeChangeRequestedUsers []string
-	for _, user := range timeChangeRequested {
-		if !user.Bot {
-			timeChangeRequestedUsers = append(timeChangeRequestedUsers, user.Username)
+	if timeChangeRequested != nil {
+		for _, user := range timeChangeRequested {
+			if !user.Bot {
+				timeChangeRequestedUsers = append(timeChangeRequestedUsers, user.Username)
+			}
 		}
 	}
 

--- a/amongushandlers/amongushandlers.go
+++ b/amongushandlers/amongushandlers.go
@@ -33,6 +33,12 @@ func messageReactionRemoveHandle(s *discordgo.Session, m *discordgo.MessageReact
 	if err != nil {
 		log.Error(errors.WithMessage(err, "Error finding message in message reaction remove handler"))
 	}
+
+	// ignore messages that were not created by the bot
+	if message.Author.ID != s.State.User.ID {
+		return
+	}
+
 	err = amongusevents.ReSyncEvent(s, message)
 	if err != nil {
 		log.Error(errors.WithMessage(err, "Error resyncing event state in reaction remove handler"))
@@ -45,7 +51,7 @@ func messageReactionAddHandle(s *discordgo.Session, m *discordgo.MessageReaction
 		log.Error(errors.WithMessage(err, "Error finding message in message reaction add handler"))
 	}
 
-	// Ignore if action was performed by the bot
+	// Ignore if action was performed by the bot or the message was not created by the bot
 	if m.MessageReaction.UserID == s.State.User.ID || message.Author.ID != s.State.User.ID {
 		return
 	}


### PR DESCRIPTION
… instead of just its own

Hotfix removing reactions to messages not managed by the bot would sometimes result in a panic if the message had zero  reactions. Added safe handling of this case and made some changes so the bot is now only looking at reactions on its own messages as previously intended.